### PR TITLE
Feature/decorator

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -37,12 +37,11 @@ function ComponentOption(cons: Cons, extend?: any) {
     const setupFunction: OptionSetupFunction | undefined = optionBuilder.setup ? function (props, ctx) {
         return optionBuilder.setup!(props, ctx)
     } : undefined
-    const decoratorKeyMap = new Map(CustomRecords.map(e=>[e.key,1]))
     const raw = {
         setup: setupFunction,
         data() {
             delete optionBuilder.data
-            optionData(cons, optionBuilder, this, [], decoratorKeyMap)
+            optionData(cons, optionBuilder, this, [])
             return optionBuilder.data ?? {}
         },
         methods: optionBuilder.methods,
@@ -88,11 +87,9 @@ function buildComponent(cons: Cons, arg: ComponentOption, extend?: any): any {
     }
     option.emits = emits
 
-    CustomRecords.forEach(rec => {
-        rec.creator.apply({}, [option, rec.key])
+    slot.obtainMap('customDecorator').forEach((v) => {
+        v.creator.apply({}, [option, v.key])
     })
-    // clear records for next component
-    CustomRecords.splice(0, CustomRecords.length)
 
     if (arg.setup) {
         if (!option.setup) {

--- a/src/custom/custom.ts
+++ b/src/custom/custom.ts
@@ -5,17 +5,22 @@ type Creator = { (options: any, key: string): void }
 export interface Record {
     key: string
     creator: Creator
+    preserve: boolean
 }
 
 export const CustomRecords: Record[] = []
 
-export function createDecorator(creator: Creator) {
+export function createDecorator(creator: Creator, opt?: {
+    preserve?: boolean
+}) {
+
     return function (proto: any, key: string) {
         const slot = obtainSlot(proto)
         const map = slot.obtainMap('customDecorator')
         map.set(key, {
             key,
-            creator
+            creator,
+            preserve: !!opt?.preserve
         })
     }
 }

--- a/src/custom/custom.ts
+++ b/src/custom/custom.ts
@@ -1,15 +1,19 @@
+import { obtainSlot } from '../utils'
+
 type Creator = { (options: any, key: string): void }
-interface Record {
+
+export interface Record {
     key: string
     creator: Creator
 }
 
-// const CustomDecorators: CustomDecorator[] = []
 export const CustomRecords: Record[] = []
 
 export function createDecorator(creator: Creator) {
     return function (proto: any, key: string) {
-        CustomRecords.push({
+        const slot = obtainSlot(proto)
+        const map = slot.obtainMap('customDecorator')
+        map.set(key, {
             key,
             creator
         })

--- a/src/option/data.ts
+++ b/src/option/data.ts
@@ -2,12 +2,11 @@ import type { Cons } from '../component'
 import type { OptionBuilder } from '../optionBuilder'
 import { makeObject, obtainSlot, excludeNames, getValidNames } from '../utils'
 
-export function build(cons: Cons, optionBuilder: OptionBuilder, vueInstance: any, _propNames?: string[],decoratorKeyMap?: Map<string,any>) {
+export function build(cons: Cons, optionBuilder: OptionBuilder, vueInstance: any, _propNames?: string[]) {
     optionBuilder.data ??= {}
     const sample = new cons(optionBuilder, vueInstance)
-
-    let names = getValidNames(sample, (des,name) => {
-        return !!des.enumerable && !decoratorKeyMap?.has(name)
+    let names = getValidNames(sample, (des) => {
+        return !!des.enumerable
     })
     const slot = obtainSlot(cons.prototype)
     names = excludeNames(names, slot)

--- a/src/option/methodsAndHooks.ts
+++ b/src/option/methodsAndHooks.ts
@@ -39,8 +39,10 @@ export function build(cons: Cons, optionBuilder: OptionBuilder) {
     optionBuilder.methods ??= {}
     const HookFunctions: Record<string, Function> = {}
     const MethodFunctions: Record<string, Function> = {}
+
     protoArr.forEach(proto => {
-        excludeNames(getValidNames(proto, (des, name) => {
+        
+        let names = getValidNames(proto, (des, name) => {
 
             if (name === 'constructor') {
                 return false
@@ -50,7 +52,10 @@ export function build(cons: Cons, optionBuilder: OptionBuilder) {
                 return true
             }
             return false
-        }), slot).forEach(name => {
+        })
+        names = excludeNames(names, slot);
+        names.forEach(name => {
+
             if (HookNames.includes(name as any) || map.has(name)) {
 
                 HookFunctions[name] = proto[name]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import type { HookConfig } from "./option/methodsAndHooks";
 import type { VModelConfig } from "./option/vmodel";
 import type { WatchConfig } from "./option/watch";
 import type { SetupConfig } from './option/setup'
+import type { Record as CustomDecoratorRecord } from './custom/custom'
 const SlotSymbol = Symbol('vue-facing-decorator-slot')
 
 export type SlotMapTypes = {
@@ -21,6 +22,7 @@ export type SlotMapTypes = {
     watch: Map<string, WatchConfig | WatchConfig[]>
     ref: Map<string, boolean>
     setup: Map<string, SetupConfig>
+    customDecorator: Map<string, CustomDecoratorRecord>
 }
 
 class Slot {
@@ -147,8 +149,7 @@ export function excludeNames(names: string[], slot: Slot) {
         let currSlot: Slot | null = slot
         while (currSlot != null) {
             for (const mapName of currSlot.names.keys()) {
-
-                if (['watch', 'hooks', 'setup','emits'].includes(mapName)) {
+                if (['watch', 'hooks', 'setup', 'emits'].includes(mapName)) {
                     continue
                 }
                 const map = currSlot.names.get(mapName)!

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,6 +152,16 @@ export function excludeNames(names: string[], slot: Slot) {
                 if (['watch', 'hooks', 'setup', 'emits'].includes(mapName)) {
                     continue
                 }
+                if (mapName === 'customDecorator') {
+                    const map = currSlot.obtainMap('customDecorator')
+                    if (map.has(name)) {
+                        if (!map.get(name)!.preserve) {
+                            return false
+                        }else{
+                            continue
+                        }
+                    }
+                }
                 const map = currSlot.names.get(mapName)!
                 if (map.has(name)) {
                     return false

--- a/test/custom/custom.ts
+++ b/test/custom/custom.ts
@@ -13,6 +13,8 @@ function CustomDeco(param?: String) {
         options.methods[key] = function (...args: any[]) {
             return `${old.apply(this, args)} ${param}`
         }
+    },{
+        preserve:true
     })
 }
 


### PR DESCRIPTION
自定义装饰器给slot加了一个map，这个map是原型上的，可以收集装饰器信息。不需要单独排除这些自定义装饰器的key了，因为excludeNames会自动做这件事。
给createDecorator加了个参数preserve，true的时候v-f-d会照常处理，false的时候会被忽略，仅应用用户装饰器